### PR TITLE
Fix Logo and NavBar

### DIFF
--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -28,7 +28,7 @@ const RegisterButton = styled(PrimaryBtn)`
 `
 
 const Container = styled.div`
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   padding: 0 1em;
   box-sizing: border-box;
@@ -49,7 +49,7 @@ const LogoContainer = styled.div`
   flex-direction: column;
   padding: 0 3em;
   min-height: 370px;
-  width: 100vw;
+  width: 100%;
   box-sizing: border-box;
 
   img {

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -18,6 +18,7 @@ const MenuContainer = styled.div`
   transition: width 0, all 0.6s;
   background-color: white;
   @media (max-width: 650px) {
+    width: 100%;
     position: fixed;
     transition: 0.6s;
     top: ${prop => (prop.isDown ? '60px' : '-300px')};

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -8,6 +8,7 @@ import { Link } from 'react-scroll'
 const Container = styled.div`
   position: fixed;
   z-index: 1000;
+  background: linear-gradient(to bottom, white 75%, transparent 100%);
 `
 const MenuContainer = styled.div`
   max-width: 970px;


### PR DESCRIPTION
- เปลี่ยน `Logo` ให้ใช้ `width: 100%` แทน `width: 100vw` 
เนื่องจากใน Windows แถบ Scrollbar แนวตั้งจะแสดงผลตลอด 
ทำให้ค่า viewport width เพี้ยน -> เนื้อหาล้นทางแนวนอน + เกิด Scrollbar

 `NavBar `
- ใส่ BG ให้เหมือนเฟดจากขาวไปโปร่งใสในช่วงท้าย ตาม Design
- แก้ไขเมนูดรอปดาวน์ Mobile กว้างไม่เต็มจอ